### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
@@ -54,6 +54,8 @@ class ITK_EXPORT GPUSmoothingRecursiveYvvGaussianImageFilter:
                                         SmoothingRecursiveYvvGaussianImageFilter< TInputImage, TOutputImage > >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(GPUSmoothingRecursiveYvvGaussianImageFilterKernel);
+
   /** Standard class typedefs. */
   typedef GPUSmoothingRecursiveYvvGaussianImageFilter Self;
   //typedef SmoothingRecursiveYvvGaussianImageFilter<TInputImage,TOutputImage>
@@ -173,9 +175,8 @@ protected:
   GPUDataPointer m_GPUMMatrixDataManager;
   GPUDataPointer m_GPUBCoefficientsDataManager;
   GPUDataPointer m_GPULocalDataManager;
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(GPUSmoothingecursiveYvvGaussianImageFilter);
 
+private:
   void BuildKernel();
 
   /** Normalize the image across scale space */

--- a/include/itkRecursiveLineYvvGaussianImageFilter.h
+++ b/include/itkRecursiveLineYvvGaussianImageFilter.h
@@ -47,6 +47,8 @@ class ITK_EXPORT RecursiveLineYvvGaussianImageFilter:
   public         InPlaceImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(RecursiveLineYvvGaussianImageFilter);
+
   /** Standard class typedefs. */
   typedef RecursiveLineYvvGaussianImageFilter             Self;
   typedef InPlaceImageFilter< TInputImage, TOutputImage > Superclass;
@@ -167,8 +169,6 @@ protected:
   // Initialization matrix for anti-causal pass
   vnl_matrix< ScalarRealType > m_MMatrix;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RecursiveLineYvvGaussianImageFilter);
-
   /** Direction in which the filter is to be applied
    * this should be in the range [0,ImageDimension-1]. */
   unsigned int m_Direction;

--- a/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
@@ -50,6 +50,8 @@ class ITK_EXPORT SmoothingRecursiveYvvGaussianImageFilter:
   public         InPlaceImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SmoothingRecursiveYvvGaussianImageFilter);
+
   /** Standard class typedefs. */
   typedef SmoothingRecursiveYvvGaussianImageFilter        Self;
   typedef InPlaceImageFilter< TInputImage, TOutputImage > Superclass;
@@ -168,8 +170,6 @@ protected:
   void EnlargeOutputRequestedRegion(DataObject *output) override;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SmoothingRecursiveYvvGaussianImageFilter);
-
   InternalGaussianFilterPointer m_SmoothingFilters[ImageDimension - 1];
   FirstGaussianFilterPointer    m_FirstSmoothingFilter;
   CastingFilterPointer          m_CastingFilter;


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.

Fix class name in `ITK_DISALLOW_COPY_AND_ASSIGN` macro declaration
argument for class `itk::GPUSmoothingRecursiveYvvGaussianImageFilter`:

`GPUSmoothingecursiveYvvGaussianImageFilter`
to
`GPUSmoothingeRecursiveYvvGaussianImageFilter`