### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/test/itkCPURecursiveYvvGaussianImageFilterTest.cxx
+++ b/test/itkCPURecursiveYvvGaussianImageFilterTest.cxx
@@ -36,9 +36,9 @@ int itkCPURecursiveYvvGaussianImageFilterTest( int argc, char* argv[] )
     }
 
   std::string  inputFilename( argv[1] );
-  unsigned int dim = atoi( argv[2] );
-  float        sigma = atof( argv[3] );
-  unsigned int ntests = atoi( argv[4] );
+  unsigned int dim = std::stoi( argv[2] );
+  float        sigma = std::stod( argv[3] );
+  unsigned int ntests = std::stoi( argv[4] );
 
   int res = EXIT_SUCCESS;
   itk::TimeProbesCollectorBase timeCollector;

--- a/test/itkGPURecursiveYvvGaussianImageFilterTest.cxx
+++ b/test/itkGPURecursiveYvvGaussianImageFilterTest.cxx
@@ -48,9 +48,9 @@ int itkGPURecursiveYvvGaussianImageFilterTest( int argc, char* argv[] )
     }
 
   std::string  inputFilename( argv[1] );
-  unsigned int dim = atoi( argv[2] );
-  float        sigma = atof( argv[3] );
-  unsigned int ntests = atoi( argv[4] );
+  unsigned int dim = std::stoi( argv[2] );
+  float        sigma = std::stod( argv[3] );
+  unsigned int ntests = std::stoi( argv[4] );
 
 
   int res = EXIT_SUCCESS;

--- a/test/itkYvvBenchmark.cxx
+++ b/test/itkYvvBenchmark.cxx
@@ -48,9 +48,9 @@ int itkYvvBenchmark( int argc, char* argv[] )
     }
 
   std::string  inputFilename( argv[1] );
-  unsigned int dim = atoi( argv[2] );
-  float        sigma = atof( argv[3] );
-  unsigned int ntests = atoi( argv[4] );
+  unsigned int dim = std::stoi( argv[2] );
+  float        sigma = std::stod( argv[3] );
+  unsigned int ntests = std::stoi( argv[4] );
 
 
   int res = EXIT_SUCCESS;

--- a/test/itkYvvGpuCpuSimilarityTest.cxx
+++ b/test/itkYvvGpuCpuSimilarityTest.cxx
@@ -212,12 +212,12 @@ int itkYvvGpuCpuSimilarityTest(int argc, char *argv[])
     }
 
   std::string inputFilename( argv[1]);
-  unsigned int dim = atoi(argv[2]);
+  unsigned int dim = std::stoi(argv[2]);
 
   float sigma=0.5;
-  if( argc >  3 && atoi(argv[3]) >= 0.5)
+  if( argc >  3 && std::stoi(argv[3]) >= 0.5)
     {
-    sigma= atof(argv[3]);
+    sigma= std::stod(argv[3]);
     }
 
   if( dim == 2 )

--- a/test/itkYvvWhiteImageTest.cxx
+++ b/test/itkYvvWhiteImageTest.cxx
@@ -50,7 +50,7 @@ int itkYvvWhiteImageTest( int argc, char* argv[] )
     die( "missing arguments." );
     }
 
-  int dim = atoi( argv[1] );
+  int dim = std::stoi( argv[1] );
   if ( argc < 4 + dim - 1 )
     {
     die( "missing arguments." );
@@ -65,11 +65,11 @@ int itkYvvWhiteImageTest( int argc, char* argv[] )
   float         sigma;
   try
     {
-    sigma = atof( argv[2] );
-    ntests = atoi( argv[3] );
+    sigma = std::stod( argv[2] );
+    ntests = std::stoi( argv[3] );
     for ( int i = 0; i < dim; ++i )
       {
-        size[i] = atoi( argv[4 + i] );
+        size[i] = std::stoi( argv[4 + i] );
       }
     }
   catch ( ... )


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/
