### PR TITLE
DOC: Follow repository naming convention.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2
 jobs:
   build-and-test:
-    working_directory: /SmoothingRecursiveYvvGaussianFilter-build
+    working_directory: /ITKSmoothingRecursiveYvvGaussianFilter-build
     docker:
       - image: insighttoolkit/module-ci:latest
     steps:
       - checkout:
-          path: /SmoothingRecursiveYvvGaussianFilter
+          path: /ITKSmoothingRecursiveYvvGaussianFilter
       - run:
           name: Fetch CTest driver script
           command: |
@@ -17,12 +17,12 @@ jobs:
             SHASNIP=$(echo $CIRCLE_SHA1 | cut -c1-7)
             cat > dashboard.cmake << EOF
             set(CTEST_SITE "CircleCI")
-            set(CTEST_BUILD_NAME "External-SmoothingRecursiveYvvGaussianFilter-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP}")
+            set(CTEST_BUILD_NAME "External-ITKSmoothingRecursiveYvvGaussianFilter-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP}")
             set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
             set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
             set(CTEST_BUILD_FLAGS: "-j5")
-            set(CTEST_SOURCE_DIRECTORY /SmoothingRecursiveYvvGaussianFilter)
-            set(CTEST_BINARY_DIRECTORY /SmoothingRecursiveYvvGaussianFilter-build)
+            set(CTEST_SOURCE_DIRECTORY /ITKSmoothingRecursiveYvvGaussianFilter)
+            set(CTEST_BINARY_DIRECTORY /ITKSmoothingRecursiveYvvGaussianFilter-build)
             set(dashboard_model Experimental)
             set(dashboard_no_clean 1)
             set(dashboard_cache "
@@ -37,7 +37,7 @@ jobs:
           command: |
             ctest -j 2 -VV -S dashboard.cmake
   package:
-    working_directory: ~/SmoothingRecursiveYvvGaussianFilter
+    working_directory: ~/ITKSmoothingRecursiveYvvGaussianFilter
     machine: true
     steps:
       - checkout

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,14 @@
-SmoothingRecursiveYvvGaussianFilter
-===================================
+ITKSmoothingRecursiveYvvGaussianFilter
+======================================
 
-.. |CircleCI| image:: https://circleci.com/gh/InsightSoftwareConsortium/SmoothingRecursiveYvvGaussianFilter.svg?style=shield
-    :target: https://circleci.com/gh/InsightSoftwareConsortium/SmoothingRecursiveYvvGaussianFilter
+.. |CircleCI| image:: https://circleci.com/gh/InsightSoftwareConsortium/ITKSmoothingRecursiveYvvGaussianFilter.svg?style=shield
+    :target: https://circleci.com/gh/InsightSoftwareConsortium/ITKSmoothingRecursiveYvvGaussianFilter
 
-.. |TravisCI| image:: https://travis-ci.org/InsightSoftwareConsortium/SmoothingRecursiveYvvGaussianFilter.svg?branch=master
-    :target: https://travis-ci.org/InsightSoftwareConsortium/SmoothingRecursiveYvvGaussianFilter
+.. |TravisCI| image:: https://travis-ci.org/InsightSoftwareConsortium/ITKSmoothingRecursiveYvvGaussianFilter.svg?branch=master
+    :target: https://travis-ci.org/InsightSoftwareConsortium/ITKSmoothingRecursiveYvvGaussianFilter
 
-.. |AppVeyor| image:: https://img.shields.io/appveyor/ci/InsightSoftwareConsortium/smoothingrecursiveyvvgaussianfilter.svg
-    :target: https://ci.appveyor.com/project/InsightSoftwareConsortium/smoothingrecursiveyvvgaussianfilter
+.. |AppVeyor| image:: https://img.shields.io/appveyor/ci/InsightSoftwareConsortium/itksmoothingrecursiveyvvgaussianfilter.svg
+    :target: https://ci.appveyor.com/project/InsightSoftwareConsortium/itksmoothingrecursiveyvvgaussianfilter
 
 =========== =========== ===========
    Linux      macOS       Windows

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,15 @@ except ImportError:
     sys.exit(1)
 
 setup(
-    name='smoothingrecursiveyvvgaussianfilter',
+    name='itk-smoothingrecursiveyvvgaussianfilter',
     version='0.0.1',
     author='Irina Vidal Migallón',
     author_email='irina.vidal-migallon@inria.fr',
     packages=['itk'],
     package_dir={'itk': 'itk'},
-    download_url=r'https://github.com/InsightSoftwareConsortium/SmoothingRecursiveYvvGaussianFilter',
+    download_url=r'https://github.com/InsightSoftwareConsortium/ITKSmoothingRecursiveYvvGaussianFilter',
     description=r'Young & Van Vliet recursive Gaussian smoothing filter for GPU (OpenCL) and CPU',
-    long_description='SmoothingRecursiveYvvGaussianFilter provides a GPU'
+    long_description='ITKSmoothingRecursiveYvvGaussianFilter provides a GPU'
                      '(OpenCL) and CPU implementation of the computationally'
                      'efficient forward and backward IIR Young & Van Vliet'
                      'recursive Gaussian smoothing filter.\n'
@@ -48,8 +48,8 @@ setup(
         "Operating System :: MacOS"
         ],
     license='Apache',
-    keywords='ITK InsightToolkit',
-    url=r'https://itk.org/',
+    keywords='ITK InsightToolkit smoothing',
+    url=r'https://github.com/InsightSoftwareConsortium/ITKSmoothingRecursiveYvvGaussianFilter',
     install_requires=[
         r'itk'
     ]


### PR DESCRIPTION
Follow remote module repository naming convention: add the `ITK` prefix to
the **project name**, and keep the prefix out of the **module name**.

Specifically:
- Fix the **project name** in the `setup` section of the `setup.py` file.
- Change the **project name** in the `config.yml` Circle CI `yml` file.
- Take advantage of the change to set the URL to the repository site in
  `setup.py`.
- Take advantage of the change to add keywords describing the module to
  `setup.py`.