### PR TITLE
ENH: Add CMake minimum required version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.10.2)
+
 project(SmoothingRecursiveYvvGaussianFilter)
 enable_testing()
 


### PR DESCRIPTION
Add a CMake minimum required version to allow building the module with
most recent CMake versions.

Set the minimum required version to the one currently recommended by ITK
master.