### PR TITLE
BUG: Fix test errors.

### DIFF
--- a/test/yvvFilter.hxx
+++ b/test/yvvFilter.hxx
@@ -110,13 +110,14 @@ template< typename FilterType >
 int testCpuFilter( std::string& filterLabel, std::string& inputFilename, typename FilterType::InputImageType::SizeType size,
                float sigma, std::string parameters, itk::TimeProbesCollectorBase* timeCollector )
 {
-  typedef typename FilterType::InputImageType InputImage;
-  typename InputImage::Pointer                src;
-  void*                                       imgPtr = &src;
-
   using InputImage = typename FilterType::InputImageType;
   typename InputImage::Pointer src;
   void *imgPtr = &src;
+
+  if( inputFilename.empty() )
+    {
+    createWhiteImage< InputImage >( imgPtr, size );
+    //createStepImage< InputImage >( imgPtr, size );
 
     std::ostringstream sizeStream;
 


### PR DESCRIPTION
Fix `yvvFilter.hxx` file redeclaration errors:
```
/ITKSmoothingRecursiveYvvGaussianFilter/test/yvvFilter.hxx: In function
'int testCpuFilter(std::__cxx11::string&, std::__cxx11::string&, typename
FilterType::InputImageType::SizeType, float, std::__cxx11::string,
itk::TimeProbesCollectorBase*)':
/ITKSmoothingRecursiveYvvGaussianFilter/test/yvvFilter.hxx:118:32: error:
redeclaration of 'typename FilterType::InputImageType::Pointer src'
   typename InputImage::Pointer src;
```