### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
@@ -55,7 +55,7 @@ class ITK_EXPORT GPUSmoothingRecursiveYvvGaussianImageFilter
                                  SmoothingRecursiveYvvGaussianImageFilter<TInputImage, TOutputImage>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(GPUSmoothingRecursiveYvvGaussianImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(GPUSmoothingRecursiveYvvGaussianImageFilter);
 
   /** Standard class type alias. */
   using Self = GPUSmoothingRecursiveYvvGaussianImageFilter;

--- a/include/itkRecursiveLineYvvGaussianImageFilter.h
+++ b/include/itkRecursiveLineYvvGaussianImageFilter.h
@@ -45,7 +45,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_EXPORT RecursiveLineYvvGaussianImageFilter : public InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(RecursiveLineYvvGaussianImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(RecursiveLineYvvGaussianImageFilter);
 
   /** Standard class type alias. */
   using Self = RecursiveLineYvvGaussianImageFilter;

--- a/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
@@ -47,7 +47,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_EXPORT SmoothingRecursiveYvvGaussianImageFilter : public InPlaceImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SmoothingRecursiveYvvGaussianImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(SmoothingRecursiveYvvGaussianImageFilter);
 
   /** Standard class type alias. */
   using Self = SmoothingRecursiveYvvGaussianImageFilter;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.