### PR TITLE
COMP: Add missing ';' at end of macro

### DIFF
--- a/include/itkRecursiveLineYvvGaussianImageFilter.hxx
+++ b/include/itkRecursiveLineYvvGaussianImageFilter.hxx
@@ -249,7 +249,7 @@ RecursiveLineYvvGaussianImageFilter<TInputImage, TOutputImage>::EnlargeOutputReq
     // verify sane parameter
     if (this->m_Direction >= outputRegion.GetImageDimension())
     {
-      itkExceptionMacro("Direction selected for filtering is greater than ImageDimension")
+      itkExceptionMacro("Direction selected for filtering is greater than ImageDimension");
     }
 
     // expand output region to match largest in the "Direction" dimension


### PR DESCRIPTION
A ';' is required at the end of macros in a future version of ITK. This will resolve build conflicts in source ITK. However, this will likely break the CI for this module until the changes are released in a future version of ITK and the CI is updated with the new version.