### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkRecursiveLineYvvGaussianImageFilter.hxx
+++ b/include/itkRecursiveLineYvvGaussianImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkRecursiveLineYvvGaussianImageFilter_hxx
 #define itkRecursiveLineYvvGaussianImageFilter_hxx
 
-#include "itkRecursiveLineYvvGaussianImageFilter.h"
 #include "itkObjectFactory.h"
 #include "itkImageLinearIteratorWithIndex.h"
 #include "itkImageLinearConstIteratorWithIndex.h"

--- a/include/itkSmoothingRecursiveYvvGaussianImageFilter.hxx
+++ b/include/itkSmoothingRecursiveYvvGaussianImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkSmoothingRecursiveYvvGaussianImageFilter_hxx
 #define itkSmoothingRecursiveYvvGaussianImageFilter_hxx
 
-#include "itkSmoothingRecursiveYvvGaussianImageFilter.h"
 #include "itkImageRegionIteratorWithIndex.h"
 #include "itkProgressAccumulator.h"
 


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

