### PR TITLE
ENH: Bump ITK version and change http links to https

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,7 +4,7 @@
 ## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
 ##
 ## The clang-format binaries can be downloaded as part of the clang binary distributions
-## from http://releases.llvm.org/download.html
+## from https://releases.llvm.org/download.html
 ##
 ## Use the script Utilities/Maintenance/clang-format.bash to faciliate
 ## maintaining a consistent code style.

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "a89145bccda6a36f42cfdd45d3a6b27234ff54fe"
+            itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -134,9 +134,9 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [36, 37, 38, 39]
+        python-version: [37, 38, 39, 310]
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.3rc04"
 
     steps:
       - uses: actions/checkout@v2
@@ -172,7 +172,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.3rc04"
 
     steps:
       - uses: actions/checkout@v2
@@ -206,9 +206,9 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [6, 7, 8, 9]
+        python-version-minor: [7, 8, 9, 10]
         include:
-          - itk-python-git-tag: "v5.2rc01"
+          - itk-python-git-tag: "v5.3rc04"
 
     steps:
       - name: Get specific version of CMake, Ninja
@@ -241,7 +241,7 @@ jobs:
         run: |
           cd ../../im
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          set PATH="C:\P\grep;%PATH%"
+          set PATH=C:\P\grep;%PATH%
           set CC=cl.exe
           set CXX=cl.exe
           C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64"

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -193,7 +193,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.rst
+++ b/README.rst
@@ -7,17 +7,17 @@ ITKSmoothingRecursiveYvvGaussianFilter
 Overview
 --------
 
-This is a module for the `Insight Toolkit (ITK) <http://itk.org>`_ that
+This is a module for the `Insight Toolkit (ITK) <https://itk.org>`_ that
 implements the Young & Van Vliet recursive Gaussian smoothing filter for GPU
 (OpenCL) and CPU.
 
-For more information, see the `Insight Journal article <http://hdl.handle.net/10380/3425>`_::
+For more information, see the `Insight Journal article <https://hdl.handle.net/10380/3425>`_::
 
   Vidal-Migallon I., Commowick O., Pennec X., Dauguet J., Vercauteren T.
   GPU and CPU implementation of Young - Van Vliet's Recursive Gaussian Smoothing Filter
   The Insight Journal. January-December. 2013.
-  http://hdl.handle.net/10380/3425
-  http://www.insight-journal.org/browse/publication/896
+  https://hdl.handle.net/10380/3425
+  https://www.insight-journal.org/browse/publication/896
 
 
 Installation

--- a/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -41,7 +41,7 @@ namespace itk
  *  the GPU performs better for your particular hardware configuration.
  *
  *  More information in the Insight Journal publication:
- *  http://hdl.handle.net/10380/3425
+ *  https://hdl.handle.net/10380/3425
  *
  * \ingroup SmoothingRecursiveYvvGaussianFilter
  */

--- a/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.hxx
+++ b/include/itkGPUSmoothingRecursiveYvvGaussianImageFilter.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkRecursiveLineYvvGaussianImageFilter.h
+++ b/include/itkRecursiveLineYvvGaussianImageFilter.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@ namespace itk
  *  performs better for your particular hardware configuration.
  *
  *  More information in the Insight Journal publication:
- *  http://hdl.handle.net/10380/3425
+ *  https://hdl.handle.net/10380/3425
  *
  * \ingroup SmoothingRecursiveYvvGaussianFilter
  */

--- a/include/itkRecursiveLineYvvGaussianImageFilter.hxx
+++ b/include/itkRecursiveLineYvvGaussianImageFilter.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
+++ b/include/itkSmoothingRecursiveYvvGaussianImageFilter.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -39,7 +39,7 @@ namespace itk
  *  performs better for your particular hardware configuration.
  *
  *  More information in the Insight Journal publication:
- *  http://hdl.handle.net/10380/3425
+ *  https://hdl.handle.net/10380/3425
  *
  * \ingroup SmoothingRecursiveYvvGaussianFilter
  */

--- a/include/itkSmoothingRecursiveYvvGaussianImageFilter.hxx
+++ b/include/itkSmoothingRecursiveYvvGaussianImageFilter.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
                      'Please refer to:\n'
                      'Vidal-Migallon I., Commowick O., Pennec X., Dauguet J., Vercauteren T.,'
                      '"GPU and CPU implementation of Young - Van Vliet\'s Recursive Gaussian Smoothing Filter", '
-                     'Insight Journal, January-December 2013, http://hdl.handle.net/10380/3425.',
+                     'Insight Journal, January-December 2013, https://hdl.handle.net/10380/3425.',
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",

--- a/src/GPUSmoothingRecursiveYvvGaussianImageFilter.cl
+++ b/src/GPUSmoothingRecursiveYvvGaussianImageFilter.cl
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkCPURecursiveYvvGaussianImageFilterTest.cxx
+++ b/test/itkCPURecursiveYvvGaussianImageFilterTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkGPURecursiveYvvGaussianImageFilterTest.cxx
+++ b/test/itkGPURecursiveYvvGaussianImageFilterTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkYvvBenchmark.cxx
+++ b/test/itkYvvBenchmark.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkYvvGpuCpuSimilarityTest.cxx
+++ b/test/itkYvvGpuCpuSimilarityTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/itkYvvWhiteImageTest.cxx
+++ b/test/itkYvvWhiteImageTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/test/yvvFilter.hxx
+++ b/test/yvvFilter.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Automated reformatting with https://github.com/InsightSoftwareConsortium/ITK/blob/master/Utilities/Maintenance/ApplyScriptToRemotes.sh