### PR TITLE
ENH: Modernize CMake to use itk_module_add_library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,8 +16,6 @@ if(ITK_USE_GPU)
 
   write_gpu_kernels("${GPU_Kernels}" GPU_SRC)
 
-  add_library(${itk-module} ${GPU_SRC})
+  itk_module_add_library(${itk-module} ${GPU_SRC})
   target_link_libraries(${itk-module} ${INRIA_ITK_LIBRARIES} ${OPENCL_LIBRARIES})
-
-  itk_module_target(${itk-module})
 endif()


### PR DESCRIPTION
Replace add_library with itk_module_add_library macro for better integration with ITK module system. This provides automatic dependency linking, include directory setup, and consistent target naming.